### PR TITLE
Better-looking grids

### DIFF
--- a/example/VisFilter.qml
+++ b/example/VisFilter.qml
@@ -62,7 +62,7 @@ Widget {
                        w*pad2 - 2*fixedpad, h*pad2 - 2*fixedpad)
         background Theme::VisualBackground
         Draw::Grid::log_x(vg, 50, 30000, box)
-        Draw::Grid::linear_y(vg, 1, 20, box)
+        Draw::Grid::linear_y(vg, 1, 10, box)
     }
 
     DataView {

--- a/example/VisHarmonic.qml
+++ b/example/VisHarmonic.qml
@@ -38,8 +38,8 @@ Widget {
 
         background Theme::VisualBackground
 
-        Draw::Grid::linear_x(vg,0,10,box, 0.5)
-        Draw::Grid::linear_y(vg,0,10,box, 0.5)
+        Draw::Grid::linear_x(vg,0,10,box, 1.0)
+        Draw::Grid::linear_y(vg,0,10,box, 1.0)
 
         xpoints = Draw::DSP::linspace(-2,2,128)
         ypoints = nil

--- a/example/WaveView.qml
+++ b/example/WaveView.qml
@@ -77,8 +77,8 @@ Widget {
         background Theme::VisualBackground
 
         if(grid)
-            Draw::Grid::linear_x(vg,0,10,box, 0.5)
-            Draw::Grid::linear_y(vg,0,10,box, 0.5)
+            Draw::Grid::linear_x(vg,0,10,box, 1.0)
+            Draw::Grid::linear_y(vg,0,10,box, 1.0)
         end
 
         if(extern.nil? || extern.empty?)

--- a/mrblib/draw-common.rb
+++ b/mrblib/draw-common.rb
@@ -237,12 +237,14 @@ module Draw
     end
     module Grid
         def self.log_y(vg, min, max, bb)
-            med_fill     = color("114575")
+            med_fill     = Theme::GridLine
             log10 = Math.log(10)
             min_  = Math.log(min)/log10
             max_  = Math.log(max)/log10
             #1,2,3,4,5,6,7,8,9,10,20
             xx = min_.to_i
+            vg.translate(0.5,0.5)
+
             loop {
                 break if xx>max_
                 base = (xx-min_)/(max_-min_)
@@ -250,84 +252,113 @@ module Draw
                 (0...10).each do |shift|
                     delta = Math.log((shift+1)*1.0)/(log10*(max_-min_))
                     dy = bb.h*(base+delta);
-
+                    
                     next if(dy < 0 || dy > bb.h)
                     vg.path do |v|
                         v.move_to(bb.x,      bb.y+dy);
                         v.line_to(bb.x+bb.w, bb.y+dy);
                         v.stroke_color med_fill
+                        v.stroke_width 1.0
                         v.stroke
                     end
                 end
                 xx += 1
             }
+
+            vg.translate(-0.5,-0.5)
         end
         def self.log_x(vg, min, max, bb)
-            med_fill     = color("114575")
+            med_fill     = Theme::GridLine
             log10 = Math.log(10)
             min_  = Math.log(min)/log10
             max_  = Math.log(max)/log10
             #1,2,3,4,5,6,7,8,9,10,20
             xx = min_.to_i
+
+            x = (bb.x).floor
+            y = (bb.y).floor
+            h = (bb.h).floor
+
+            vg.translate(0.5,0.5)
+
             loop {
                 break if xx>max_
                 base = (xx-min_)/(max_-min_)
 
                 (0...10).each do |shift|
                     delta = Math.log((shift+1)*1.0)/(log10*(max_-min_))
-                    dx = bb.w*(base+delta);
+                    dx = (bb.w*(base+delta)).floor;
 
                     next if(dx < 0 || dx > bb.w)
                     vg.path do |v|
-                        v.move_to(bb.x+dx, bb.y);
-                        v.line_to(bb.x+dx, bb.y+bb.h);
+                        v.move_to(x+dx, y);
+                        v.line_to(x+dx, y+h);
                         v.stroke_color med_fill
-                        v.stroke_width 2
+                        v.stroke_width 1.0
                         v.stroke
                     end
                 end
                 xx += 1
             }
+
+            vg.translate(-0.5,-0.5)
         end
         def self.linear_x(vg, min, max, bb, thick=1.0)
             med_fill     = Theme::GridLine
             light_fill   = Theme::GridLine
             c = max
+
+            x = (bb.x).floor
+            y = (bb.y).floor
+            h = (bb.h).floor
+
+            vg.translate(0.5,0.5)
+
             (0..c).each do |ln|
                 vg.path do |v|
-                    off = (ln/c)*(bb.w)
-                    vg.move_to(bb.x+off, bb.y)
-                    vg.line_to(bb.x+off, bb.y+bb.h)
+                    off = ((ln/c)*(bb.w)).floor
+                    vg.move_to(x+off, y)
+                    vg.line_to(x+off, y+h)
                     if((ln%10) == 0)
                         v.stroke_color med_fill
-                        v.stroke_width 4.0*thick
+                        v.stroke_width 1.0*thick
                     else
                         v.stroke_color light_fill
-                        v.stroke_width 2.0*thick
+                        v.stroke_width 1.0*thick
                     end
                     v.stroke
                 end
             end
+            vg.translate(-0.5,-0.5)
         end
         def self.linear_y(vg, min, max, bb, thick=1.0, c=40)
             med_fill     = Theme::GridLine
             light_fill   = Theme::GridLine
             c = max
+            
+            x = (bb.x).floor
+            y = (bb.y).floor
+            w = (bb.w).floor
+            h = (bb.h).floor
+
+            vg.translate(0.5,0.5)
+
             (0..c).each do |ln|
                 vg.path do |v|
-                    off = (ln/c)*(bb.h)
-                    vg.move_to(bb.x,      bb.y+off)
-                    vg.line_to(bb.x+bb.w, bb.y+off)
+                    off = ((ln/c)*(bb.h)).floor
+                    vg.move_to(x,   y+off)
+                    vg.line_to(x+w, y+off)
                     if((ln%10) == 0)
                         v.stroke_color med_fill
-                        v.stroke_width 4.0*thick
+                        v.stroke_width 1.0*thick
                     else
                         v.stroke_color light_fill
-                        v.stroke_width 2.0*thick
+                        v.stroke_width 1.0*thick
                     end
                     v.stroke
                 end
             end
+            vg.translate(-0.5,-0.5)
         end
     end
 


### PR DESCRIPTION
This makes the grids look crisper (1px line without smudge), and makes the filter display less cluttered. Maybe it's a bit hard to see the improvement, but I think it's there :) (if you look at the screenshots at 100% zoom, that is)

Before:
![2018-07-16-21 33 34](https://user-images.githubusercontent.com/23723605/42791900-d0245d2c-8940-11e8-8b11-3120513847a8.png)

After:
![2018-07-16-21 33 38](https://user-images.githubusercontent.com/23723605/42791903-d461a548-8940-11e8-9087-a6e75c23635f.png)

Before:
![2018-07-16-21 33 57](https://user-images.githubusercontent.com/23723605/42791937-02860432-8941-11e8-810e-a70922d96187.png)

After:
![2018-07-16-21 34 02](https://user-images.githubusercontent.com/23723605/42791948-0b4289e2-8941-11e8-980c-b2c2b93ebbe8.png)

Before:
![2018-07-16-21 36 53](https://user-images.githubusercontent.com/23723605/42792206-3ca0e0a0-8942-11e8-8d3e-c0ef595d9118.png)

After:
![2018-07-16-21 36 57](https://user-images.githubusercontent.com/23723605/42792210-4038ed7a-8942-11e8-9811-854a76ff1f10.png)
