### PR TITLE
Gradients for envelopes

### DIFF
--- a/mrblib/draw-common.rb
+++ b/mrblib/draw-common.rb
@@ -76,17 +76,23 @@ module Draw
         def self.under_highlight(vg, bb, dat, fill)
             n = dat.length
             vg.scissor(bb.x, bb.y+bb.h/2, bb.w, bb.h/2)
+            max_y = bb.y+bb.h/2
             vg.path do
                 vg.move_to(0.0, 0.0);
                 i = 0
                 while(i<n)
-                    vg.line_to(bb.x + bb.w*dat[i].x,
-                               bb.y + bb.h/2*(1-dat[i].y));
-                    i += 1
+                    dest_x = bb.x + bb.w*dat[i].x;
+                    dest_y = bb.y + bb.h/2*(1-dat[i].y);
+                    vg.line_to(dest_x, dest_y);
+                    i += 1;
+                    if (dest_y > max_y)
+                        max_y = dest_y;
+                    end
                 end
                 vg.line_to(bb.x+bb.w, 0.0)
                 vg.close_path
-                vg.fill_color fill
+                paint = vg.linear_gradient(bb.x, bb.y+bb.h/2,bb.x, max_y, NVG.rgba(16, 59, 79, 0), NVG.rgba(16, 59, 79, 255))
+                vg.fill_paint paint
                 vg.fill
             end
             vg.reset_scissor
@@ -95,15 +101,21 @@ module Draw
         def self.over_highlight(vg, bb, dat, fill)
             n = dat.length
             vg.scissor(bb.x, bb.y, bb.w, bb.h/2);
+            min_y = bb.y+bb.h/2
             vg.path do
                 vg.move_to(0.0,bb.y+bb.h)
                 (0...n).each do |i|
-                    vg.line_to(bb.x + bb.w*dat[i].x,
-                               bb.y + bb.h/2*(1-dat[i].y));
+                    dest_x = bb.x + bb.w*dat[i].x;
+                    dest_y = bb.y + bb.h/2*(1-dat[i].y);
+                    vg.line_to(dest_x, dest_y);
+                    if (dest_y < min_y)
+                        min_y = dest_y;
+                    end
                 end
                 vg.line_to(bb.x+bb.w,bb.y+bb.h)
                 vg.close_path
-                vg.fill_color fill
+                paint = vg.linear_gradient(bb.x, bb.y+bb.h/2,bb.x, min_y, NVG.rgba(16, 59, 79, 0), NVG.rgba(16, 59, 79, 255))
+                vg.fill_paint paint
                 vg.fill
             end
             vg.reset_scissor
@@ -752,7 +764,7 @@ module Theme
 
     TitleBar            = ButtonGrad1
     #Visualizations
-    VisualBackground    = color("212121")
+    VisualBackground    = color("1C1C1C")
     VisualStroke        = color("014767")
     VisualLightFill     = color("014767",55)
     VisualBright        = color("3ac5ec")

--- a/mrblib/draw-common.rb
+++ b/mrblib/draw-common.rb
@@ -764,7 +764,7 @@ module Theme
 
     TitleBar            = ButtonGrad1
     #Visualizations
-    VisualBackground    = color("1C1C1C")
+    VisualBackground    = color("212121")
     VisualStroke        = color("014767")
     VisualLightFill     = color("014767",55)
     VisualBright        = color("3ac5ec")


### PR DESCRIPTION
Before:
![2018-07-18-16 15 25](https://user-images.githubusercontent.com/23723605/42905847-2adc15fe-8aa7-11e8-86eb-bab211efe6a4.png)

After:
![2018-07-18-16 15 19](https://user-images.githubusercontent.com/23723605/42905850-2e3793ae-8aa7-11e8-85cc-9169f1fb32fc.png)
![2018-07-18-16 27 14](https://user-images.githubusercontent.com/23723605/42905932-7a368dfa-8aa7-11e8-9b5b-246d0f4dc2d0.png)

Now, I want to add those to the filter views.

EDIT: I'll revert the background color change in the next commit. Seems like a color profile was messing with the colors I was seeing in the mockup.