### PR TITLE
Search box behavior improvement

### DIFF
--- a/example/SearchBox.qml
+++ b/example/SearchBox.qml
@@ -29,7 +29,11 @@ Widget {
         vg.font_size h*0.8
         vg.text_align NVG::ALIGN_LEFT | NVG::ALIGN_MIDDLE
         vg.fill_color = Theme::TextColor
-        l = label.empty? ? "search..." : label
+        l = label
+        if(root.key_widget != self and label.empty?)
+            vg.fill_color = Theme::BackgroundTextColor
+            l = "search..."
+        end
         vg.text(8,h/2,l.upcase)
         bnd = vg.text_bounds(0,0,l.upcase)
         if(@state)

--- a/example/ZynBank.qml
+++ b/example/ZynBank.qml
@@ -62,7 +62,7 @@ Widget {
         id: lhs
         SearchBox {
             id: search
-            whenValue: lambda { bank.doSearch}
+            whenValue: lambda { bank.doSearch }
         }
         Widget {
             SelColumn {

--- a/mrblib/draw-common.rb
+++ b/mrblib/draw-common.rb
@@ -751,6 +751,7 @@ module Theme
     HarmonicColor       = color("026392")
 
     TextColor           = color("CECECE")
+    BackgroundTextColor = color("818181")
     TextActiveColor     = color("52FAFE")
     TextModColor        = color("5BDBBA")
 


### PR DESCRIPTION
This PR only does cosmetic changes the the search box that appear in the browser panel to make it closer to similar web-based widgets.

The "search..." background help text is shown grayed-out, to make it clearer that's it's not actual content but a tip.
The help text is only visible when the field is not focused. 
