### PR TITLE
TextScroll and SelColumn scroll one line at a time.

### DIFF
--- a/example/ScrollBar.qml
+++ b/example/ScrollBar.qml
@@ -1,4 +1,5 @@
 Valuator {
+    // Relative size of the scroll bar handle to the full length.
     property Float  bar_size: 0.1
     property Symbol style: :normal
 

--- a/example/SelColumn.qml
+++ b/example/SelColumn.qml
@@ -21,7 +21,7 @@ Widget {
             col.clear_sel if col.clear_on_extern
             col.setValue(col.filter(x)) if !col.skip
             col.setValue(x)             if  col.skip
-            // Resets the scroll bar to the top.
+            # Resets the scroll bar to the top.
             scroll.value = 1.0
         }
     }

--- a/qml/TextScroll.qml
+++ b/qml/TextScroll.qml
@@ -2,37 +2,55 @@ Widget {
     id: text
     property signal action: nil;
     property Color  textColor: Theme::TextColor
+    // Number of text lines visible in the widget.
     property Int    lines: 30
     property Object valueRef: nil
     property Int    off: 0
 
-
+    // Internal property, not meant to be changed from outside.
+    property Int _content_lines: -1
 
     function class_name() { "TextScroll" }
 
     ScrollBar {
         id: scroll
+        bar_size: scrollbar_size()
         whenValue: lambda { text.tryScroll }
+    }
+
+    function scrollbar_size()
+    {
+        compute_content_lines()
+        ratio = [0.05, [1.0, lines.to_f / _content_lines].min].max
+        ratio
     }
     
     function onScroll(ev)
     {
-        scroll.onScroll(ev)
+        return if !scroll.active
+        scroll.updatePos(-ev.dy.to_f/(_content_lines-lines))
     }
 
-    function num_lines()
+    function compute_content_lines()
     {
-        ind = 0
-        self.label.each_line do |l|
-            ind += 1
+        if (self._content_lines > -1)
+          return
         end
-        ind
+        self._content_lines = 0
+        self.label.each_line do |l|
+            self._content_lines += 1
+        end
+        self._content_lines
     }
 
     function tryScroll()
     {
-        ln = num_lines()
-        start = (1-scroll.value)*(ln-lines)
+        if ((_content_lines - lines) <= 0)
+          self.off = 0
+          damage_self
+          return
+        end
+        start = (1.0-scroll.value)*(_content_lines-lines) + 0.5
         start = start.to_i
         if(start != self.off)
             self.off = start


### PR DESCRIPTION
The new behavior is consistent with standard widgets: each tick on the mouse wheel scrolls the text by exactly one line.

Also the size of the scrollbar matches the relative size of the text and the viewport in TextScroll.