### PR TITLE
Widget tooltips now disappear on mouse leave

### DIFF
--- a/qml/Widget.qml
+++ b/qml/Widget.qml
@@ -147,4 +147,12 @@ Object {
             widget.y
         end
     }
+
+    function onMouseLeave(ev)
+    {
+        if (self.root.respond_to?(:log))
+            self.root.log(:tooltip, "")
+        end
+    }
+
 }


### PR DESCRIPTION
The original tooltip behavior of changing only when the pointer moves in another widget which also has a tooltip rather confused me when I first started using Zynfusion. I think making sure the tooltip is only displayed when the mouse pointer is over the widget is easier to follow. It is also more consistent with what other UI toolkits do.

This depends on https://github.com/mruby-zest/mruby-zest-build/pull/39 to work, but the two PRs can be submitted in any order without problems.