### PR TITLE
Knob.label is not ignored anymore.

### DIFF
--- a/qml/Valuator.qml
+++ b/qml/Valuator.qml
@@ -18,7 +18,7 @@ Widget {
 
     onExtern: {
         meta = OSC::RemoteMetadata.new($remote, valuator.extern)
-        valuator.label   = meta.short_name
+        valuator.label   = meta.short_name if valuator.label == ""
         valuator.tooltip = meta.tooltip
         valuator.units   = meta.units
 


### PR DESCRIPTION
Yet another tiny UI improvement.

In the case where a knob is attached to a remote value, the short name
of that remote value is set as the label, overwriting whichever value
was set when constructing the object.

Visible impact prior to this change: in the macro learn panel, the
offset knobs were labeled "off" despite having a label in
ZynAutomationParam.qml set to "offset".