### PR TITLE
Fixed a crash when moving to the Effects view.

### DIFF
--- a/example/ZynAutomationSlot.qml
+++ b/example/ZynAutomationSlot.qml
@@ -9,9 +9,6 @@ Widget {
     }
 
     //Draw the header
-    //PowButton {
-    //    id: pow
-    //}
     ClearBox {
         id: clr
         tooltip: "clear automation slot"
@@ -19,7 +16,7 @@ Widget {
     }
     Widget {
         TextField {
-            id: name
+            id: slot_name
             label: "slot"
         }
         HSlider {
@@ -47,8 +44,7 @@ Widget {
     }
 
     onExtern: {
-        #pow.extern   = slot.extern + "active"
-        name.extern  = slot.extern + "name"
+        slot_name.extern  = slot.extern + "name"
         slide.extern = slot.extern + "value"
     }
 

--- a/example/ZynSendToRow.qml
+++ b/example/ZynSendToRow.qml
@@ -3,14 +3,14 @@ Widget {
     property Int row_id: 0
     property Int cols:   4
     TextSel {
-        id: name
+        id: send_name
         extern: "/sysefx#{row.row_id}/efftype"
     }
 
     function onSetup(old=nil)
     {
         return if children.length > 1
-        name.label = (row.row_id+1).to_s + " reverb"
+        send_name.label = (row.row_id+1).to_s + " reverb"
         (cols-row_id).times do |x|
             ch = Qml::HSlider.new(db)
             ch.extern = "/sysefxfrom#{row_id}/to#{x+row_id+1}"


### PR DESCRIPTION
This crash seems to have been caused by the mruby upgrade to version 3.
The crash could be trigger by clicking on the "Effects" button in the left side-panel.

Root cause:
`name` is now an attribute of every object, which contains the type of
the object (e.g. "Widget"). Using "name" as an id is not possible anymore.

The change in ZynSendToRow fixes the crash, the other change is preventative (I haven't found a way to trigger a crash there).