### PR TITLE
Factored out the tooltip code into Widget

### DIFF
--- a/example/FancyButton.qml
+++ b/example/FancyButton.qml
@@ -27,12 +27,6 @@ Widget {
         damage_self
     }
 
-    function onMouseEnter(ev) {
-        if(self.tooltip != "")
-            self.root.log(:tooltip, self.tooltip)
-        end
-    }
-
     function draw(vg)
     {
         pad = 0

--- a/example/KitButton.qml
+++ b/example/KitButton.qml
@@ -2,15 +2,9 @@ Widget {
     id: button
     property signal action: nil;
     property Bool   value:    false;
-    property Bool   enable:   false
+    property Bool   enable:   false;
     tooltip: "Use Middle Mouse To Toggle"
     
-    function onMouseEnter(ev) {
-        if(self.tooltip != "")
-            self.root.log(:tooltip, self.tooltip)
-        end
-    }
-
     function set_enable(v) {
         if(button.enable != v)
             button.enable = v

--- a/example/SelButton.qml
+++ b/example/SelButton.qml
@@ -54,9 +54,4 @@ Button {
         end
         vg.text(8,h/2,ll)
     }
-    function onMouseEnter(ev) {
-        if(self.tooltip != "")
-            self.root.log(:tooltip, self.tooltip)
-        end
-    }
 }

--- a/example/SidebarButton.qml
+++ b/example/SidebarButton.qml
@@ -4,12 +4,6 @@ Widget {
     property Bool value: false
     tooltip: ""
 
-    function onMouseEnter(ev) {
-        if(self.tooltip != "")
-            self.root.log(:tooltip, self.tooltip)
-        end
-    }
-
     function onMousePress(ev) {
         self.value = !self.value
         damage_self

--- a/example/ZynAutomationParam.qml
+++ b/example/ZynAutomationParam.qml
@@ -49,6 +49,7 @@ Widget {
 
         ClearBox {
             id: clr
+            tooltip: "remove this parameter from the slot"
             whenValue: lambda {$remote.action(param.extern + "clear")}
         }
     }

--- a/qml/Button.qml
+++ b/qml/Button.qml
@@ -15,12 +15,6 @@ Widget {
         whenValue.call if whenValue
     }
 
-    function onMouseEnter(ev) {
-        if(self.tooltip != "")
-            self.root.log(:tooltip, self.tooltip)
-        end
-    }
-
     function onMerge(val)
     {
         button.value = val.value if(val.respond_to? :value)

--- a/qml/NumEntry.qml
+++ b/qml/NumEntry.qml
@@ -113,12 +113,6 @@ Widget {
         updatePos(-1) if ev.dy < 0
     }
 
-    function onMouseEnter(ev) {
-        if(self.tooltip != "")
-            self.root.log(:tooltip, self.tooltip)
-        end
-    }
-
     function onMousePress(ev)
     {
         return if !ev.buttons.include? :leftButton

--- a/qml/Selector.qml
+++ b/qml/Selector.qml
@@ -112,12 +112,6 @@ Widget {
         create_menu if self.active && options.length != 1
     }
 
-    function onMouseEnter(ev) {
-        if(self.tooltip != "")
-            self.root.log(:tooltip, self.tooltip)
-        end
-    }
-
     function draw_strike(vg)
     {
         pad  = 1.0/64

--- a/qml/Widget.qml
+++ b/qml/Widget.qml
@@ -147,6 +147,12 @@ Object {
             widget.y
         end
     }
+    
+    function onMouseEnter(ev) {
+        if(self.tooltip != "" and self.root.respond_to?(:log))
+            self.root.log(:tooltip, self.tooltip)
+        end
+    }
 
     function onMouseLeave(ev)
     {


### PR DESCRIPTION
The only visible consequence of this is that the "clear" buttons in the "macro learn" panel now show a tooltip - it was broken before.

This was the occasion to move multiple identical methods into Widget, with the nice consequence that now all widgets support tooltips.